### PR TITLE
issue-4: added AppArmor security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,22 @@ $ docker run \
   -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket \
   --privileged -p 49971:49971 device-ble
 ```
+
+#### AppArmor
+ If you are running the device service on a system with AppArmor,
+ to be able to run the device service without requiring the `--privileged` 
+ flag please apply the provided security policy  `docker-ble-policy` 
+ using the command:
+ 
+```shell
+$ sudo apparmor_parser -r -W docker-ble-policy
+```
+
+If this security policy has been applied to the system, the `--security-opt` 
+flag replaces the  `--privileged` flag when running the device service:
+
+```shell
+$ docker run \
+  -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket \
+  --security-opt apparmor=docker-ble-policy -p 49971:49971 device-ble
+```

--- a/docker-ble-policy
+++ b/docker-ble-policy
@@ -1,0 +1,40 @@
+#include <tunables/global>
+
+profile docker-ble-policy flags=(attach_disconnected,mediate_deleted) {
+
+  #include <abstractions/base>
+  #include <abstractions/dbus-strict>
+
+  dbus (send) bus=system peer=(name=org.bluez, label=unconfined),
+  dbus (send, receive) bus=system interface=org.freedesktop.DBus.ObjectManager peer=(label=unconfined),
+
+  network,
+  capability,
+  file,
+  umount,
+
+  signal (send,receive) peer=docker-ble-policy,
+
+  deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
+  # deny write to files not in /proc/<number>/** or /proc/sys/**
+  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+  deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
+  deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
+  deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/kcore rwklx,
+
+  deny mount,
+
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+
+
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read,tracedby,readby) peer=docker-ble-policy,
+
+}


### PR DESCRIPTION
 and instructions on how to apply it in README

refering to issue: edgexfoundry-holding/device-bluetooth-c/issues/4

still require security policy for SELinux

