### PR TITLE
cmake-fail: updated libsdk cmake to utilise CSDK_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if (NOT LIBDBUS_FOUND)
     message (WARNING "D-Bus library or header not found")
 endif ()
 
-include_directories (${DBUS_INCLUDE_DIR} ${DBUS_ARCH_INCLUDE_DIR})
+include_directories (${DBUS_INCLUDE_DIR} ${DBUS_ARCH_INCLUDE_DIR} ${LIBCSDK_INCLUDE_DIR})
 
 # Set additional C compiler flags
 if (DEFINED CMAKE_C_COMPILER_ID)

--- a/cmake/FindLibcsdk.cmake
+++ b/cmake/FindLibcsdk.cmake
@@ -1,4 +1,12 @@
-find_path(LIBCSDK_INCLUDE_DIR edgex/edgex.h edgex/devsdk.h)
-find_library(LIBCSDK_LIBRARIES NAMES csdk libcsdk)
+find_library(LIBCSDK_LIBRARIES NAMES csdk libcsdk PATHS ENV CSDK_DIR PATH_SUFFIXES lib)
+if(LIBCSDK_LIBRARIES STREQUAL "LIBCSDK_LIBRARIES-NOTFOUND")
+    message(FATAL_ERROR "No C SDK library found in the default paths or $CSDK_DIR/lib. Please check your installation.")
+endif()
+
+find_path(LIBCSDK_INCLUDE_DIR edgex/edgex.h edgex/devsdk.h PATHS ENV CSDK_DIR PATH_SUFFIXES include)
+if(LIBCSDK_INCLUDE_DIR STREQUAL "LIBCSDK_INCLUDE_DIR-NOTFOUND")
+    message(FATAL_ERROR "No C SDK header found in the default paths or $CSDK_DIR/include. Please check your installation.")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LIBCSDK DEFAULT_MSG LIBCSDK_LIBRARIES LIBCSDK_INCLUDE_DIR)


### PR DESCRIPTION
Based on issue raised by @tonyespy in https://github.com/edgexfoundry-holding/device-bluetooth-c/pull/22

@tonyespy could you check this change allows you to build the device service now?
